### PR TITLE
Update Lykke.Service.RaiblocksApi.Services.csproj

### DIFF
--- a/src/Lykke.Service.RaiblocksApi.Services/Lykke.Service.RaiblocksApi.Services.csproj
+++ b/src/Lykke.Service.RaiblocksApi.Services/Lykke.Service.RaiblocksApi.Services.csproj
@@ -6,6 +6,14 @@
     <RootNamespace>Lykke.Service.RaiblocksApi.Services</RootNamespace>
     <Version>1.0.0</Version>
   </PropertyGroup>
+   
+   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Lykke.Common" Version="6.0.0" />


### PR DESCRIPTION
Build fail from command line fix. More detail: https://stackoverflow.com/questions/46090274/build-dotnet-core-2-0-exe-with-c7-1 . One actual error from command line: [build] RaiBlockchainService.cs(170,20): error CS8306: Tuple element name 'Frontier' is inferred. Please use language version 7.1 or greater to access an element by its inferred name.